### PR TITLE
In observe_step, check to see if the value read from the object changes

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -534,7 +534,9 @@ void observe_step(lwm2m_context_t * contextP,
             {
                 bool notify = false;
 
-                if (watcherP->update == true)
+                if (watcherP->update == true ||
+                    LWM2M_TYPE_INTEGER == dataP->type && watcherP->lastValue.asInteger != integerValue ||
+                    LWM2M_TYPE_FLOAT == dataP->type && watcherP->lastValue.asFloat != floatValue)
                 {
                     // value changed, should we notify the server ?
 


### PR DESCRIPTION
This uses a  different lastValue for each observer which is correct,
given the implementation of step change observations here.

KEVA-2339