### PR TITLE
Do not check value of data when there is no data to check.

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -543,10 +543,10 @@ void observe_step(lwm2m_context_t * contextP,
             {
                 bool notify = false;
 
-                if (watcherP->update == true ||
-                    LWM2M_TYPE_INTEGER == dataP->type && watcherP->lastValue.asInteger != integerValue ||
-                    LWM2M_TYPE_FLOAT == dataP->type && watcherP->lastValue.asFloat != floatValue ||
-                    LWM2M_TYPE_BOOLEAN == dataP->type && watcherP->lastValue.asBoolean != boolValue)
+                if (watcherP->update == true || (NULL != dataP &&
+                    (LWM2M_TYPE_INTEGER == dataP->type && watcherP->lastValue.asInteger != integerValue ||
+                     LWM2M_TYPE_FLOAT == dataP->type && watcherP->lastValue.asFloat != floatValue ||
+                     LWM2M_TYPE_BOOLEAN == dataP->type && watcherP->lastValue.asBoolean != boolValue)))
                 {
                     // value changed, should we notify the server ?
 


### PR DESCRIPTION
This change will not interfere with the previous implementation of
observe_step. If lwm2m_resource_value_changed is called then this will
work, however I am not sure if an observe on an object works at all.